### PR TITLE
[blog] launch stable diffusion

### DIFF
--- a/site/blog/unlisted/stable-diffusion.mdx
+++ b/site/blog/unlisted/stable-diffusion.mdx
@@ -1,0 +1,55 @@
+---
+slug: stable-diffusion
+title: Deploy Stable Diffusion to your AWS account with one click
+date: 2022-11-15
+authors: [depombo]
+---
+
+# Deploy Stable Diffusion to an EC2 instance in your AWS account with one click
+
+:::caution
+
+The on-demand pricing for the `p3.2xlarge` EC2 instance used is around $3 per hour. For exact pricing check https://aws.amazon.com/ec2/pricing/on-demand/
+
+:::caution
+
+
+```sql TheButton[Deploy Stable Diffusion]="Deploy Stable Diffusion"
+
+-- Manage AWS EC2 service with IaSQL
+SELECT * FROM iasql_install('aws_ec2');
+
+-- how to provide hugging face credentials programmatically
+INSERT INTO instance (region, ami, instance_type, tags, user_data)
+  VALUES ('us-east-2', 'ami-077454f43efd38e42', 'p3.2xlarge', '{"name":"iasql-stable-diffusion"}', 'sudo yum install ec2-instance-connect;
+pip3 install anaconda;
+git lfs install;
+git clone https://huggingface.co/CompVis/stable-diffusion-v1-4;
+git lfs pull;
+');
+
+INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
+  (SELECT id FROM instance WHERE tags ->> 'name' = 'iasql-stable-diffusion'),
+  (SELECT id FROM security_group WHERE group_name='default' AND vpc_id = (SELECT id FROM vpc WHERE is_default = true LIMIT 1));
+
+-- enable ssh access to vm
+INSERT INTO security_group (description, group_name)
+VALUES ('Security Group from IaSQL sample', 'iasql-ssh');
+
+INSERT INTO security_group_rule (is_egress, ip_protocol, from_port, to_port, cidr_ipv4, description, security_group_id)
+SELECT false, 'tcp', 22, 22, '0.0.0.0/0', 'iasqlsshrule', id
+FROM security_group
+WHERE group_name = 'iasql-ssh';
+
+INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
+  (SELECT id FROM instance WHERE tags ->> 'name' = 'iasql-stable-diffusion'),
+  (SELECT id FROM security_group WHERE group_name='iasql-ssh');
+
+-- Previewing changes in your account
+SELECT * FROM iasql_preview_apply();
+-- Applying delete changes, please uncomment it to perform the cleanup
+--SELECT * FROM iasql_apply();
+```
+
+After the initial module install, IaSQL will propose the creation of a new virtual machine.
+If you agree with the proposed changes uncomment the apply statement and execute it to let IaSQL spin up the EC2 instance.

--- a/site/blog/unlisted/stable-diffusion.mdx
+++ b/site/blog/unlisted/stable-diffusion.mdx
@@ -44,11 +44,6 @@ WHERE group_name = 'iasql-ssh';
 INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
   (SELECT id FROM instance WHERE tags ->> 'name' = 'iasql-stable-diffusion'),
   (SELECT id FROM security_group WHERE group_name='iasql-ssh');
-
--- Previewing changes in your account
-SELECT * FROM iasql_preview_apply();
--- Applying delete changes, please uncomment it to perform the cleanup
---SELECT * FROM iasql_apply();
 ```
 
 After the initial module install, IaSQL will propose the creation of a new virtual machine.

--- a/site/docs/sample-queries/aws_ec2.md
+++ b/site/docs/sample-queries/aws_ec2.md
@@ -28,7 +28,7 @@ INSERT INTO instance (ami, instance_type, tags)
 
 INSERT INTO instance_security_groups (instance_id, security_group_id) SELECT
   (SELECT id FROM instance WHERE tags ->> 'name' = 'i-1'),
-  (SELECT id FROM security_group WHERE group_name='default' AND vpc_id = (SELECT id FROM vpc WHERE is_default = true));
+  (SELECT id FROM security_group WHERE group_name='default' AND vpc_id = (SELECT id FROM vpc WHERE is_default = true LIMIT 1));
 
 INSERT INTO instance (ami, instance_type, tags)
   VALUES ('resolve:ssm:/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id', 't2.micro', '{"name":"i-2"}');

--- a/site/docs/sample-queries/aws_security_group.md
+++ b/site/docs/sample-queries/aws_security_group.md
@@ -28,8 +28,8 @@ SELECT true, 'tcp', 443, 443, '0.0.0.0/8', 'iasqlsamplerule', id
 FROM security_group
 WHERE group_name = 'iasql-sample-sg';
 
-INSERT INTO security_group_rule (is_egress, ip_protocol, from_port, to_port, cidr_ipv6, description, security_group_id)
-SELECT false, 'tcp', 22, 22, '::/8', 'iasqlsamplerule2', id
+INSERT INTO security_group_rule (is_egress, ip_protocol, from_port, to_port, cidr_ipv4, description, security_group_id)
+SELECT false, 'tcp', 22, 22, '0.0.0.0/0', 'iasqlsamplerule2', id
 FROM security_group
 WHERE group_name = 'iasql-sample-sg';
 ```


### PR DESCRIPTION
a few road bumps that prevent a fully programmatic creation thus far:
- the ami id used by the main tutorials is part of AWS marketplace and the terms need to be agreed upon in the aws console https://aws.amazon.com/marketplace/server/procurement?productId=e6724620-3ffb-4cc9-9690-c310d8e794ef
- if no ec2 instances of significant size have been spin up thus far, the apply loop immediately hits an AWS error limit from exceeding the cpu quota and there needs to be a claim to increase the quota https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-ec2-instances&serviceLimitIncreaseType=ec2-instances&type=service_limit_increase
- hugging face requires creating an account and providing the credentials to be able to download the model https://huggingface.co/CompVis/stable-diffusion-v1-4?text=A+high+tech+solarpunk+utopia+in+the+Amazon+rainforest

these can be addressed later or just included in the tutorial