### PR TITLE
Add signature for RPC functions

### DIFF
--- a/src/modules/aws_acm/rpcs/import.ts
+++ b/src/modules/aws_acm/rpcs/import.ts
@@ -35,10 +35,10 @@ export class CertificateImportRpc extends RpcBase {
   } as const;
 
   inputTable: RpcInput = [
-    { ArgName: 'certificate', ArgType: 'varchar' },
-    { ArgName: 'privateKey', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar' },
-    { ArgName: 'options', ArgType: 'varchar' },
+    { argName: 'certificate', argType: 'varchar' },
+    { argName: 'privateKey', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar' },
+    { argName: 'options', argType: 'varchar' },
   ];
 
   /**

--- a/src/modules/aws_acm/rpcs/import.ts
+++ b/src/modules/aws_acm/rpcs/import.ts
@@ -33,7 +33,9 @@ export class CertificateImportRpc extends RpcBase {
     status: 'varchar',
     message: 'varchar',
   } as const;
-
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     certificate: 'varchar',
     privateKey: 'varchar',

--- a/src/modules/aws_acm/rpcs/import.ts
+++ b/src/modules/aws_acm/rpcs/import.ts
@@ -2,7 +2,7 @@ import { ACM, ImportCertificateCommandInput, paginateListCertificates } from '@a
 
 import { AwsAcmModule } from '..';
 import { AWS, paginateBuilder } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { Certificate } from '../entity';
 import { safeParse } from './common';
 
@@ -33,6 +33,13 @@ export class CertificateImportRpc extends RpcBase {
     status: 'varchar',
     message: 'varchar',
   } as const;
+
+  inputTable: RpcInput = [
+    { ArgName: 'certificate', ArgType: 'varchar' },
+    { ArgName: 'privateKey', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar' },
+    { ArgName: 'options', ArgType: 'varchar' },
+  ];
 
   /**
    * @internal

--- a/src/modules/aws_acm/rpcs/import.ts
+++ b/src/modules/aws_acm/rpcs/import.ts
@@ -34,12 +34,12 @@ export class CertificateImportRpc extends RpcBase {
     message: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [
-    { argName: 'certificate', argType: 'varchar' },
-    { argName: 'privateKey', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar' },
-    { argName: 'options', argType: 'varchar' },
-  ];
+  inputTable: RpcInput = {
+    certificate: 'varchar',
+    privateKey: 'varchar',
+    region: 'varchar',
+    options: { argType: 'json', default: '{}' },
+  };
 
   /**
    * @internal

--- a/src/modules/aws_acm/rpcs/request.ts
+++ b/src/modules/aws_acm/rpcs/request.ts
@@ -54,10 +54,10 @@ export class CertificateRequestRpc extends RpcBase {
   } as const;
 
   inputTable: RpcInput = [
-    { ArgName: 'domainName', ArgType: 'varchar' },
-    { ArgName: 'validationMethod', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar' },
-    { ArgName: 'options', ArgType: 'json' },
+    { argName: 'domainName', argType: 'varchar' },
+    { argName: 'validationMethod', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar' },
+    { argName: 'options', argType: 'json' },
   ];
 
   /**

--- a/src/modules/aws_acm/rpcs/request.ts
+++ b/src/modules/aws_acm/rpcs/request.ts
@@ -53,12 +53,12 @@ export class CertificateRequestRpc extends RpcBase {
     message: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [
-    { argName: 'domainName', argType: 'varchar' },
-    { argName: 'validationMethod', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar' },
-    { argName: 'options', argType: 'json' },
-  ];
+  inputTable: RpcInput = {
+    domainName: 'varchar',
+    validationMethod: 'varchar',
+    region: 'varchar',
+    options: { argType: 'json', default: '{}' },
+  };
 
   /**
    * @internal

--- a/src/modules/aws_acm/rpcs/request.ts
+++ b/src/modules/aws_acm/rpcs/request.ts
@@ -15,7 +15,7 @@ import { AWS, paginateBuilder } from '../../../services/aws_macros';
 import { awsRoute53Module } from '../../aws_route53';
 import { HostedZone, ResourceRecordSet } from '../../aws_route53/entity';
 import { modules } from '../../iasql_functions/iasql';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { Certificate } from '../entity';
 import { safeParse } from './common';
 
@@ -52,6 +52,13 @@ export class CertificateRequestRpc extends RpcBase {
     status: 'varchar',
     message: 'varchar',
   } as const;
+
+  inputTable: RpcInput = [
+    { ArgName: 'domainName', ArgType: 'varchar' },
+    { ArgName: 'validationMethod', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar' },
+    { ArgName: 'options', ArgType: 'json' },
+  ];
 
   /**
    * @internal

--- a/src/modules/aws_acm/rpcs/request.ts
+++ b/src/modules/aws_acm/rpcs/request.ts
@@ -52,7 +52,9 @@ export class CertificateRequestRpc extends RpcBase {
     status: 'varchar',
     message: 'varchar',
   } as const;
-
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     domainName: 'varchar',
     validationMethod: 'varchar',

--- a/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
+++ b/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
@@ -31,10 +31,10 @@ export class LogGroupTailRpc extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable: RpcInput = [
-    { argName: 'logGroupName', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
-  ];
+  inputTable: RpcInput = {
+    logGroupName: 'varchar',
+    region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },
+  };
   /** @internal */
   outputTable = {
     event_id: 'varchar',

--- a/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
+++ b/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
@@ -32,8 +32,8 @@ export class LogGroupTailRpc extends RpcBase {
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
   inputTable: RpcInput = [
-    { ArgName: 'logGroupName', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+    { argName: 'logGroupName', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
   ];
   /** @internal */
   outputTable = {

--- a/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
+++ b/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
@@ -31,6 +31,7 @@ export class LogGroupTailRpc extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable: RpcInput = {
     logGroupName: 'varchar',
     region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },

--- a/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
+++ b/src/modules/aws_cloudwatch/rpcs/log_group_tail.ts
@@ -7,6 +7,7 @@ import {
   PostTransactionCheck,
   PreTransactionCheck,
   RpcBase,
+  RpcInput,
   RpcResponseObject,
 } from '../../interfaces';
 
@@ -30,6 +31,10 @@ export class LogGroupTailRpc extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable: RpcInput = [
+    { ArgName: 'logGroupName', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+  ];
   /** @internal */
   outputTable = {
     event_id: 'varchar',

--- a/src/modules/aws_codebuild/rpcs/import_source_credential.ts
+++ b/src/modules/aws_codebuild/rpcs/import_source_credential.ts
@@ -34,6 +34,7 @@ export class ImportSourceCredentialRpc extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
 
+  /** @internal */
   inputTable: RpcInput = {
     region: 'varchar',
     token: 'varchar',

--- a/src/modules/aws_codebuild/rpcs/import_source_credential.ts
+++ b/src/modules/aws_codebuild/rpcs/import_source_credential.ts
@@ -34,12 +34,12 @@ export class ImportSourceCredentialRpc extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
 
-  inputTable: RpcInput = [
-    { argName: 'region', argType: 'varchar' },
-    { argName: 'token', argType: 'varchar' },
-    { argName: 'serverType', argType: 'varchar', default: "'GITHUB'" },
-    { argName: 'authType', argType: 'varchar', default: "'PERSONAL_ACCESS_TOKEN'" },
-  ];
+  inputTable: RpcInput = {
+    region: 'varchar',
+    token: 'varchar',
+    serverType: { argType: 'varchar', default: 'GITHUB' },
+    authType: { argType: 'varchar', default: 'PERSONAL_ACCESS_TOKEN' },
+  };
 
   /** @internal */
   outputTable = {

--- a/src/modules/aws_codebuild/rpcs/import_source_credential.ts
+++ b/src/modules/aws_codebuild/rpcs/import_source_credential.ts
@@ -35,10 +35,10 @@ export class ImportSourceCredentialRpc extends RpcBase {
   module: AwsCodebuildModule;
 
   inputTable: RpcInput = [
-    { ArgName: 'region', ArgType: 'varchar' },
-    { ArgName: 'token', ArgType: 'varchar' },
-    { ArgName: 'serverType', ArgType: 'varchar', Default: "'GITHUB'" },
-    { ArgName: 'authType', ArgType: 'varchar', Default: "'PERSONAL_ACCESS_TOKEN'" },
+    { argName: 'region', argType: 'varchar' },
+    { argName: 'token', argType: 'varchar' },
+    { argName: 'serverType', argType: 'varchar', default: "'GITHUB'" },
+    { argName: 'authType', argType: 'varchar', default: "'PERSONAL_ACCESS_TOKEN'" },
   ];
 
   /** @internal */

--- a/src/modules/aws_codebuild/rpcs/import_source_credential.ts
+++ b/src/modules/aws_codebuild/rpcs/import_source_credential.ts
@@ -1,8 +1,7 @@
-import { Build, CodeBuild, ImportSourceCredentialsInput } from '@aws-sdk/client-codebuild';
-import { ServerType } from '@aws-sdk/client-codebuild/dist-types/models/models_0';
+import { CodeBuild, ImportSourceCredentialsInput } from '@aws-sdk/client-codebuild';
 
 import { AWS, crudBuilderFormat } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { AwsCodebuildModule } from '../index';
 
 export enum ValidServerTypes {
@@ -34,6 +33,13 @@ export enum ValidAuthTypes {
 export class ImportSourceCredentialRpc extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
+
+  inputTable: RpcInput = [
+    { ArgName: 'region', ArgType: 'varchar' },
+    { ArgName: 'token', ArgType: 'varchar' },
+    { ArgName: 'serverType', ArgType: 'varchar', Default: "'GITHUB'" },
+    { ArgName: 'authType', ArgType: 'varchar', Default: "'PERSONAL_ACCESS_TOKEN'" },
+  ];
 
   /** @internal */
   outputTable = {
@@ -81,8 +87,6 @@ export class ImportSourceCredentialRpc extends RpcBase {
     serverType: string,
     authType: string,
   ): Promise<RpcResponseObject<typeof this.outputTable>[]> => {
-    if (!serverType) serverType = 'GITHUB';
-    if (!authType) authType = 'PERSONAL_ACCESS_TOKEN';
     if (!(serverType in ValidServerTypes))
       return this.makeError(`serverType must be one of ${Object.keys(ValidServerTypes).join(', ')}`);
     if (!(authType in ValidAuthTypes))

--- a/src/modules/aws_codebuild/rpcs/start_build.ts
+++ b/src/modules/aws_codebuild/rpcs/start_build.ts
@@ -23,8 +23,8 @@ export class StartBuildRPC extends RpcBase {
   module: AwsCodebuildModule;
 
   inputTable: RpcInput = [
-    { ArgName: 'codeBuildProjectName', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+    { argName: 'codeBuildProjectName', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
   ];
   /** @internal */
   outputTable = {

--- a/src/modules/aws_codebuild/rpcs/start_build.ts
+++ b/src/modules/aws_codebuild/rpcs/start_build.ts
@@ -22,10 +22,10 @@ export class StartBuildRPC extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
 
-  inputTable: RpcInput = [
-    { argName: 'codeBuildProjectName', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
-  ];
+  inputTable: RpcInput = {
+    codeBuildProjectName: 'varchar',
+    region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },
+  };
   /** @internal */
   outputTable = {
     name: 'varchar',

--- a/src/modules/aws_codebuild/rpcs/start_build.ts
+++ b/src/modules/aws_codebuild/rpcs/start_build.ts
@@ -22,6 +22,7 @@ export class StartBuildRPC extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
 
+  /** @internal */
   inputTable: RpcInput = {
     codeBuildProjectName: 'varchar',
     region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },

--- a/src/modules/aws_codebuild/rpcs/start_build.ts
+++ b/src/modules/aws_codebuild/rpcs/start_build.ts
@@ -2,7 +2,7 @@ import { Build, CodeBuild } from '@aws-sdk/client-codebuild';
 
 import { AwsCodebuildModule } from '..';
 import { AWS, crudBuilderFormat } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for triggering the build of a project
@@ -22,6 +22,10 @@ export class StartBuildRPC extends RpcBase {
   /** @internal */
   module: AwsCodebuildModule;
 
+  inputTable: RpcInput = [
+    { ArgName: 'codeBuildProjectName', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+  ];
   /** @internal */
   outputTable = {
     name: 'varchar',

--- a/src/modules/aws_codedeploy/rpcs/start_deploy.ts
+++ b/src/modules/aws_codedeploy/rpcs/start_deploy.ts
@@ -38,6 +38,7 @@ export class StartDeployRPC extends RpcBase {
   /** @internal */
   module: AwsCodedeployModule;
 
+  /** @internal */
   inputTable: RpcInput = {
     applicationName: 'varchar',
     deploymentGroupName: 'varchar',

--- a/src/modules/aws_codedeploy/rpcs/start_deploy.ts
+++ b/src/modules/aws_codedeploy/rpcs/start_deploy.ts
@@ -39,10 +39,10 @@ export class StartDeployRPC extends RpcBase {
   module: AwsCodedeployModule;
 
   inputTable: RpcInput = [
-    { ArgName: 'applicationName', ArgType: 'varchar' },
-    { ArgName: 'deploymentGroupName', ArgType: 'varchar' },
-    { ArgName: 'revision', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+    { argName: 'applicationName', argType: 'varchar' },
+    { argName: 'deploymentGroupName', argType: 'varchar' },
+    { argName: 'revision', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
   ];
   /** @internal */
   outputTable = {

--- a/src/modules/aws_codedeploy/rpcs/start_deploy.ts
+++ b/src/modules/aws_codedeploy/rpcs/start_deploy.ts
@@ -38,12 +38,12 @@ export class StartDeployRPC extends RpcBase {
   /** @internal */
   module: AwsCodedeployModule;
 
-  inputTable: RpcInput = [
-    { argName: 'applicationName', argType: 'varchar' },
-    { argName: 'deploymentGroupName', argType: 'varchar' },
-    { argName: 'revision', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
-  ];
+  inputTable: RpcInput = {
+    applicationName: 'varchar',
+    deploymentGroupName: 'varchar',
+    revision: 'varchar',
+    region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },
+  };
   /** @internal */
   outputTable = {
     id: 'varchar',

--- a/src/modules/aws_codedeploy/rpcs/start_deploy.ts
+++ b/src/modules/aws_codedeploy/rpcs/start_deploy.ts
@@ -8,7 +8,7 @@ import { WaiterOptions } from '@aws-sdk/util-waiter';
 
 import { AwsCodedeployModule } from '..';
 import { AWS, crudBuilderFormat } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for deploying a CodeDeploy application revision through a deployment group.
@@ -38,6 +38,12 @@ export class StartDeployRPC extends RpcBase {
   /** @internal */
   module: AwsCodedeployModule;
 
+  inputTable: RpcInput = [
+    { ArgName: 'applicationName', ArgType: 'varchar' },
+    { ArgName: 'deploymentGroupName', ArgType: 'varchar' },
+    { ArgName: 'revision', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+  ];
   /** @internal */
   outputTable = {
     id: 'varchar',

--- a/src/modules/aws_ec2/rpcs/import.ts
+++ b/src/modules/aws_ec2/rpcs/import.ts
@@ -3,7 +3,7 @@ import { WaiterOptions, WaiterState } from '@aws-sdk/util-waiter';
 
 import { AwsEc2Module } from '..';
 import { AWS } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for importing EC2 keypairs, based on a local one.
@@ -22,6 +22,11 @@ export class KeyPairImportRpc extends RpcBase {
    * @internal
    */
   module: AwsEc2Module;
+  inputTable: RpcInput = [
+    { ArgName: 'keyName', ArgType: 'varchar' },
+    { ArgName: 'publicKey', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar' },
+  ];
   /**
    * @internal
    */

--- a/src/modules/aws_ec2/rpcs/import.ts
+++ b/src/modules/aws_ec2/rpcs/import.ts
@@ -22,6 +22,7 @@ export class KeyPairImportRpc extends RpcBase {
    * @internal
    */
   module: AwsEc2Module;
+  /** @internal */
   inputTable: RpcInput = {
     keyName: 'varchar',
     publicKey: 'varchar',

--- a/src/modules/aws_ec2/rpcs/import.ts
+++ b/src/modules/aws_ec2/rpcs/import.ts
@@ -23,9 +23,9 @@ export class KeyPairImportRpc extends RpcBase {
    */
   module: AwsEc2Module;
   inputTable: RpcInput = [
-    { ArgName: 'keyName', ArgType: 'varchar' },
-    { ArgName: 'publicKey', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar' },
+    { argName: 'keyName', argType: 'varchar' },
+    { argName: 'publicKey', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar' },
   ];
   /**
    * @internal

--- a/src/modules/aws_ec2/rpcs/import.ts
+++ b/src/modules/aws_ec2/rpcs/import.ts
@@ -22,11 +22,11 @@ export class KeyPairImportRpc extends RpcBase {
    * @internal
    */
   module: AwsEc2Module;
-  inputTable: RpcInput = [
-    { argName: 'keyName', argType: 'varchar' },
-    { argName: 'publicKey', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar' },
-  ];
+  inputTable: RpcInput = {
+    keyName: 'varchar',
+    publicKey: 'varchar',
+    region: 'varchar',
+  };
   /**
    * @internal
    */

--- a/src/modules/aws_ec2/rpcs/request.ts
+++ b/src/modules/aws_ec2/rpcs/request.ts
@@ -40,12 +40,12 @@ export class KeyPairRequestRpc extends RpcBase {
     privateKey: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [
-    { argName: 'keyPairName', argType: 'varchar' },
-    { argName: 'region', argType: 'varchar' },
-    { argName: 'keyFormat', argType: 'varchar', default: "'pem'" },
-    { argName: 'keyType', argType: 'varchar', default: "'rsa'" },
-  ];
+  inputTable: RpcInput = {
+    keyPairName: 'varchar',
+    region: 'varchar',
+    keyFormat: { argType: 'varchar', default: 'pem' },
+    keyType: { argType: 'varchar', default: 'rsa' },
+  };
 
   /**
    * @internal

--- a/src/modules/aws_ec2/rpcs/request.ts
+++ b/src/modules/aws_ec2/rpcs/request.ts
@@ -9,7 +9,7 @@ import { WaiterOptions, WaiterState } from '@aws-sdk/util-waiter';
 
 import { AwsEc2Module } from '..';
 import { AWS } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for requesting a new EC2 keypair
@@ -40,11 +40,11 @@ export class KeyPairRequestRpc extends RpcBase {
     privateKey: 'varchar',
   } as const;
 
-  inputTable = [
-    { ArgName: 'keyPairName', ArgType: 'varchar' },
-    { ArgName: 'region', ArgType: 'varchar' },
-    { ArgName: 'keyFormat', ArgType: 'varchar', Default: "'pem'" },
-    { ArgName: 'keyType', ArgType: 'varchar', Default: "'rsa'" },
+  inputTable: RpcInput = [
+    { argName: 'keyPairName', argType: 'varchar' },
+    { argName: 'region', argType: 'varchar' },
+    { argName: 'keyFormat', argType: 'varchar', default: "'pem'" },
+    { argName: 'keyType', argType: 'varchar', default: "'rsa'" },
   ];
 
   /**

--- a/src/modules/aws_ec2/rpcs/request.ts
+++ b/src/modules/aws_ec2/rpcs/request.ts
@@ -40,6 +40,7 @@ export class KeyPairRequestRpc extends RpcBase {
     privateKey: 'varchar',
   } as const;
 
+  /** @internal */
   inputTable: RpcInput = {
     keyPairName: 'varchar',
     region: 'varchar',

--- a/src/modules/aws_ec2/rpcs/request.ts
+++ b/src/modules/aws_ec2/rpcs/request.ts
@@ -1,5 +1,10 @@
-import { CreateKeyPairCommandInput, EC2, waitUntilKeyPairExists } from '@aws-sdk/client-ec2';
-import { KeyFormat, KeyType } from '@aws-sdk/client-ec2';
+import {
+  CreateKeyPairCommandInput,
+  EC2,
+  KeyFormat,
+  KeyType,
+  waitUntilKeyPairExists,
+} from '@aws-sdk/client-ec2';
 import { WaiterOptions, WaiterState } from '@aws-sdk/util-waiter';
 
 import { AwsEc2Module } from '..';
@@ -35,6 +40,13 @@ export class KeyPairRequestRpc extends RpcBase {
     privateKey: 'varchar',
   } as const;
 
+  inputTable = [
+    { ArgName: 'keyPairName', ArgType: 'varchar' },
+    { ArgName: 'region', ArgType: 'varchar' },
+    { ArgName: 'keyFormat', ArgType: 'varchar', Default: "'pem'" },
+    { ArgName: 'keyType', ArgType: 'varchar', Default: "'rsa'" },
+  ];
+
   /**
    * @internal
    */
@@ -63,15 +75,14 @@ export class KeyPairRequestRpc extends RpcBase {
     ctx: Context,
     name: string,
     region: string,
-    keyFormat?: string,
-    keyType?: string,
+    keyFormat: string,
+    keyType: string,
   ): Promise<RpcResponseObject<typeof this.outputTable>[]> => {
     const client = (await ctx.getAwsClient(region)) as AWS;
-    const textEncoder = new TextEncoder();
     const input: CreateKeyPairCommandInput = {
       KeyName: name,
-      KeyFormat: (keyFormat ?? 'pem') as KeyFormat,
-      KeyType: (keyType ?? 'rsa') as KeyType,
+      KeyFormat: keyFormat as KeyFormat,
+      KeyType: keyType as KeyType,
     };
     const result = await this.requestKeyPair(client.ec2client, input);
     if (!result) {

--- a/src/modules/aws_ecr/rpcs/build.ts
+++ b/src/modules/aws_ecr/rpcs/build.ts
@@ -37,11 +37,11 @@ export class EcrBuildRpc extends RpcBase {
   } as const;
 
   inputTable: RpcInput = [
-    { ArgName: 'githubRepoUrl', ArgType: 'varchar' },
-    { ArgName: 'ecrRepositoryId', ArgType: 'varchar' },
-    { ArgName: 'buildPath', ArgType: 'varchar', Default: "''" },
-    { ArgName: 'githubRef', ArgType: 'varchar', Default: "''" },
-    { ArgName: 'githubPersonalAccessToken', ArgType: 'varchar', Default: "''" },
+    { argName: 'githubRepoUrl', argType: 'varchar' },
+    { argName: 'ecrRepositoryId', argType: 'varchar' },
+    { argName: 'buildPath', argType: 'varchar', default: "''" },
+    { argName: 'githubRef', argType: 'varchar', default: "''" },
+    { argName: 'githubPersonalAccessToken', argType: 'varchar', default: "''" },
   ];
 
   /**

--- a/src/modules/aws_ecr/rpcs/build.ts
+++ b/src/modules/aws_ecr/rpcs/build.ts
@@ -3,7 +3,7 @@ import { CodebuildProject, SourceCredentialsList, SourceType } from '../../aws_c
 import { awsIamModule } from '../../aws_iam';
 import { IamRole } from '../../aws_iam/entity';
 import { modules } from '../../iasql_functions/iasql';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { Repository, RepositoryImage } from '../entity';
 import { AwsEcrModule } from '../index';
 
@@ -35,6 +35,14 @@ export class EcrBuildRpc extends RpcBase {
   outputTable = {
     imageId: 'varchar',
   } as const;
+
+  inputTable: RpcInput = [
+    { ArgName: 'githubRepoUrl', ArgType: 'varchar' },
+    { ArgName: 'ecrRepositoryId', ArgType: 'varchar' },
+    { ArgName: 'buildPath', ArgType: 'varchar', Default: "''" },
+    { ArgName: 'githubRef', ArgType: 'varchar', Default: "''" },
+    { ArgName: 'githubPersonalAccessToken', ArgType: 'varchar', Default: "''" },
+  ];
 
   /**
    * @internal

--- a/src/modules/aws_ecr/rpcs/build.ts
+++ b/src/modules/aws_ecr/rpcs/build.ts
@@ -36,13 +36,13 @@ export class EcrBuildRpc extends RpcBase {
     imageId: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [
-    { argName: 'githubRepoUrl', argType: 'varchar' },
-    { argName: 'ecrRepositoryId', argType: 'varchar' },
-    { argName: 'buildPath', argType: 'varchar', default: "''" },
-    { argName: 'githubRef', argType: 'varchar', default: "''" },
-    { argName: 'githubPersonalAccessToken', argType: 'varchar', default: "''" },
-  ];
+  inputTable: RpcInput = {
+    githubRepoUrl: 'varchar',
+    ecrRepositoryId: 'varchar',
+    buildPath: { argType: 'varchar', default: '' },
+    githubRef: { argType: 'varchar', default: '' },
+    githubPersonalAccessToken: { argType: 'varchar', default: '' },
+  };
 
   /**
    * @internal

--- a/src/modules/aws_ecr/rpcs/build.ts
+++ b/src/modules/aws_ecr/rpcs/build.ts
@@ -36,6 +36,9 @@ export class EcrBuildRpc extends RpcBase {
     imageId: 'varchar',
   } as const;
 
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     githubRepoUrl: 'varchar',
     ecrRepositoryId: 'varchar',

--- a/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
+++ b/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
@@ -34,6 +34,9 @@ export class DeployServiceRPC extends RpcBase {
     message: 'varchar',
   } as const;
 
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     serviceArn: 'varchar',
   };

--- a/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
+++ b/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
@@ -34,7 +34,7 @@ export class DeployServiceRPC extends RpcBase {
     message: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [{ ArgName: 'serviceArn', ArgType: 'varchar' }];
+  inputTable: RpcInput = [{ argName: 'serviceArn', argType: 'varchar' }];
   /**
    * @internal
    */

--- a/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
+++ b/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
@@ -2,7 +2,7 @@ import { ECS, UpdateServiceCommandInput } from '@aws-sdk/client-ecs';
 
 import { AwsEcsFargateModule } from '..';
 import { AWS } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { Service } from '../entity';
 
 /**
@@ -34,6 +34,7 @@ export class DeployServiceRPC extends RpcBase {
     message: 'varchar',
   } as const;
 
+  inputTable: RpcInput = [{ ArgName: 'serviceArn', ArgType: 'varchar' }];
   /**
    * @internal
    */

--- a/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
+++ b/src/modules/aws_ecs_fargate/rpcs/deploy_service.ts
@@ -34,7 +34,9 @@ export class DeployServiceRPC extends RpcBase {
     message: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [{ argName: 'serviceArn', argType: 'varchar' }];
+  inputTable: RpcInput = {
+    serviceArn: 'varchar',
+  };
   /**
    * @internal
    */

--- a/src/modules/aws_iam/rpcs/request.ts
+++ b/src/modules/aws_iam/rpcs/request.ts
@@ -33,7 +33,9 @@ export class AccessKeyRequestRpc extends RpcBase {
     accessKeyId: 'varchar',
     secretAccessKey: 'varchar',
   } as const;
-
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     userName: 'varchar',
   };

--- a/src/modules/aws_iam/rpcs/request.ts
+++ b/src/modules/aws_iam/rpcs/request.ts
@@ -34,8 +34,9 @@ export class AccessKeyRequestRpc extends RpcBase {
     secretAccessKey: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [{ argName: 'userName', argType: 'varchar' }];
-
+  inputTable: RpcInput = {
+    userName: 'varchar',
+  };
   /**
    * @internal
    */

--- a/src/modules/aws_iam/rpcs/request.ts
+++ b/src/modules/aws_iam/rpcs/request.ts
@@ -34,7 +34,7 @@ export class AccessKeyRequestRpc extends RpcBase {
     secretAccessKey: 'varchar',
   } as const;
 
-  inputTable: RpcInput = [{ ArgName: 'userName', ArgType: 'varchar' }];
+  inputTable: RpcInput = [{ argName: 'userName', argType: 'varchar' }];
 
   /**
    * @internal

--- a/src/modules/aws_iam/rpcs/request.ts
+++ b/src/modules/aws_iam/rpcs/request.ts
@@ -2,7 +2,7 @@ import { CreateAccessKeyCommandInput, IAM } from '@aws-sdk/client-iam';
 
 import { AwsIamModule } from '..';
 import { AWS } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for requesting a new Access Key for an IAM user
@@ -33,6 +33,8 @@ export class AccessKeyRequestRpc extends RpcBase {
     accessKeyId: 'varchar',
     secretAccessKey: 'varchar',
   } as const;
+
+  inputTable: RpcInput = [{ ArgName: 'userName', ArgType: 'varchar' }];
 
   /**
    * @internal

--- a/src/modules/aws_iam/rpcs/set_password.ts
+++ b/src/modules/aws_iam/rpcs/set_password.ts
@@ -34,6 +34,9 @@ export class SetUserPasswordRequestRpc extends RpcBase {
    */
   module: AwsIamModule;
 
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     userName: 'varchar',
     password: 'varchar',

--- a/src/modules/aws_iam/rpcs/set_password.ts
+++ b/src/modules/aws_iam/rpcs/set_password.ts
@@ -35,9 +35,9 @@ export class SetUserPasswordRequestRpc extends RpcBase {
   module: AwsIamModule;
 
   inputTable: RpcInput = [
-    { ArgName: 'userName', ArgType: 'varchar' },
-    { ArgName: 'password', ArgType: 'varchar', Default: 'NULL' },
-    { ArgName: 'resetPassword', ArgType: 'varchar', Default: 'FALSE' },
+    { argName: 'userName', argType: 'varchar' },
+    { argName: 'password', argType: 'varchar', default: 'NULL' },
+    { argName: 'resetPassword', argType: 'varchar', default: 'FALSE' },
   ];
 
   /**

--- a/src/modules/aws_iam/rpcs/set_password.ts
+++ b/src/modules/aws_iam/rpcs/set_password.ts
@@ -7,7 +7,7 @@ import {
 
 import { AwsIamModule } from '..';
 import { AWS, crudBuilder2, crudBuilderFormat } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 
 /**
  * Method for requesting a new password for an IAM user
@@ -33,6 +33,12 @@ export class SetUserPasswordRequestRpc extends RpcBase {
    * @internal
    */
   module: AwsIamModule;
+
+  inputTable: RpcInput = [
+    { ArgName: 'userName', ArgType: 'varchar' },
+    { ArgName: 'password', ArgType: 'varchar', Default: 'NULL' },
+    { ArgName: 'resetPassword', ArgType: 'varchar', Default: 'FALSE' },
+  ];
 
   /**
    * @internal

--- a/src/modules/aws_iam/rpcs/set_password.ts
+++ b/src/modules/aws_iam/rpcs/set_password.ts
@@ -34,11 +34,11 @@ export class SetUserPasswordRequestRpc extends RpcBase {
    */
   module: AwsIamModule;
 
-  inputTable: RpcInput = [
-    { argName: 'userName', argType: 'varchar' },
-    { argName: 'password', argType: 'varchar', default: 'NULL' },
-    { argName: 'resetPassword', argType: 'varchar', default: 'FALSE' },
-  ];
+  inputTable: RpcInput = {
+    userName: 'varchar',
+    password: 'varchar',
+    resetPassword: { argType: 'varchar', default: false },
+  };
 
   /**
    * @internal

--- a/src/modules/aws_lambda/rpcs/invoke.ts
+++ b/src/modules/aws_lambda/rpcs/invoke.ts
@@ -30,11 +30,11 @@ export class LambdaFunctionInvokeRpc extends RpcBase {
    */
   module: AwsLambdaModule;
 
-  inputTable: RpcInput = [
-    { argName: 'lambdaFunctionName', argType: 'varchar' },
-    { argName: 'functionPayload', argType: 'json', default: "'{}'" },
-    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
-  ];
+  inputTable: RpcInput = {
+    lambdaFunctionName: 'varchar',
+    functionPayload: { argType: 'json', default: '{}' },
+    region: { argType: 'varchar', default: 'default_aws_region()', rawDefault: true },
+  };
   /**
    * @internal
    */

--- a/src/modules/aws_lambda/rpcs/invoke.ts
+++ b/src/modules/aws_lambda/rpcs/invoke.ts
@@ -3,7 +3,7 @@ import { InvokeCommandInput, InvokeCommandOutput } from '@aws-sdk/client-lambda'
 import { AwsLambdaModule } from '..';
 import { AWS } from '../../../services/aws_macros';
 import { awsCloudwatchModule } from '../../aws_cloudwatch';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { invokeFunction } from '../aws';
 
 /**
@@ -30,6 +30,11 @@ export class LambdaFunctionInvokeRpc extends RpcBase {
    */
   module: AwsLambdaModule;
 
+  inputTable: RpcInput = [
+    { ArgName: 'lambdaFunctionName', ArgType: 'varchar' },
+    { ArgName: 'functionPayload', ArgType: 'json', Default: "'{}'" },
+    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+  ];
   /**
    * @internal
    */

--- a/src/modules/aws_lambda/rpcs/invoke.ts
+++ b/src/modules/aws_lambda/rpcs/invoke.ts
@@ -30,6 +30,9 @@ export class LambdaFunctionInvokeRpc extends RpcBase {
    */
   module: AwsLambdaModule;
 
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     lambdaFunctionName: 'varchar',
     functionPayload: { argType: 'json', default: '{}' },

--- a/src/modules/aws_lambda/rpcs/invoke.ts
+++ b/src/modules/aws_lambda/rpcs/invoke.ts
@@ -31,9 +31,9 @@ export class LambdaFunctionInvokeRpc extends RpcBase {
   module: AwsLambdaModule;
 
   inputTable: RpcInput = [
-    { ArgName: 'lambdaFunctionName', ArgType: 'varchar' },
-    { ArgName: 'functionPayload', ArgType: 'json', Default: "'{}'" },
-    { ArgName: 'region', ArgType: 'varchar', Default: 'default_aws_region()' },
+    { argName: 'lambdaFunctionName', argType: 'varchar' },
+    { argName: 'functionPayload', argType: 'json', default: "'{}'" },
+    { argName: 'region', argType: 'varchar', default: 'default_aws_region()' },
   ];
   /**
    * @internal

--- a/src/modules/aws_s3/rpcs/s3_upload_object.ts
+++ b/src/modules/aws_s3/rpcs/s3_upload_object.ts
@@ -30,12 +30,12 @@ export class S3UploadObjectRpc extends RpcBase {
    */
   module: AwsS3Module;
 
-  inputTable: RpcInput = [
-    { argName: 'bucketName', argType: 'varchar' },
-    { argName: 'bucketKey', argType: 'varchar' },
-    { argName: 'fileContent', argType: 'varchar' },
-    { argName: 'contentType', argType: 'varchar' },
-  ];
+  inputTable: RpcInput = {
+    bucketName: 'varchar',
+    bucketKey: 'varchar',
+    fileContent: 'varchar',
+    contentType: 'varchar',
+  };
   /**
    * @internal
    */

--- a/src/modules/aws_s3/rpcs/s3_upload_object.ts
+++ b/src/modules/aws_s3/rpcs/s3_upload_object.ts
@@ -31,10 +31,10 @@ export class S3UploadObjectRpc extends RpcBase {
   module: AwsS3Module;
 
   inputTable: RpcInput = [
-    { ArgName: 'bucketName', ArgType: 'varchar' },
-    { ArgName: 'bucketKey', ArgType: 'varchar' },
-    { ArgName: 'fileContent', ArgType: 'varchar' },
-    { ArgName: 'contentType', ArgType: 'varchar' },
+    { argName: 'bucketName', argType: 'varchar' },
+    { argName: 'bucketKey', argType: 'varchar' },
+    { argName: 'fileContent', argType: 'varchar' },
+    { argName: 'contentType', argType: 'varchar' },
   ];
   /**
    * @internal

--- a/src/modules/aws_s3/rpcs/s3_upload_object.ts
+++ b/src/modules/aws_s3/rpcs/s3_upload_object.ts
@@ -30,6 +30,9 @@ export class S3UploadObjectRpc extends RpcBase {
    */
   module: AwsS3Module;
 
+  /**
+   * @internal
+   */
   inputTable: RpcInput = {
     bucketName: 'varchar',
     bucketKey: 'varchar',

--- a/src/modules/aws_s3/rpcs/s3_upload_object.ts
+++ b/src/modules/aws_s3/rpcs/s3_upload_object.ts
@@ -3,7 +3,7 @@ import { WaiterOptions } from '@aws-sdk/util-waiter';
 
 import { AwsS3Module } from '..';
 import { AWS, crudBuilderFormat } from '../../../services/aws_macros';
-import { Context, RpcBase, RpcResponseObject } from '../../interfaces';
+import { Context, RpcBase, RpcInput, RpcResponseObject } from '../../interfaces';
 import { BucketObject } from '../entity';
 
 /**
@@ -30,6 +30,12 @@ export class S3UploadObjectRpc extends RpcBase {
    */
   module: AwsS3Module;
 
+  inputTable: RpcInput = [
+    { ArgName: 'bucketName', ArgType: 'varchar' },
+    { ArgName: 'bucketKey', ArgType: 'varchar' },
+    { ArgName: 'fileContent', ArgType: 'varchar' },
+    { ArgName: 'contentType', ArgType: 'varchar' },
+  ];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_apply.ts
@@ -23,6 +23,7 @@ export class IasqlApply extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_apply.ts
@@ -23,7 +23,7 @@ export class IasqlApply extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_apply.ts
@@ -23,6 +23,9 @@ export class IasqlApply extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /**
+   * @internal
+   */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_begin.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_begin.ts
@@ -22,6 +22,7 @@ export class IasqlBegin extends RpcBase {
   preTransactionCheck = PreTransactionCheck.WAIT_FOR_LOCK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /** @internal */
   outputTable = {

--- a/src/modules/iasql_functions/rpcs/iasql_begin.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_begin.ts
@@ -22,7 +22,7 @@ export class IasqlBegin extends RpcBase {
   preTransactionCheck = PreTransactionCheck.WAIT_FOR_LOCK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /** @internal */
   outputTable = {
     message: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_begin.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_begin.ts
@@ -22,6 +22,7 @@ export class IasqlBegin extends RpcBase {
   preTransactionCheck = PreTransactionCheck.WAIT_FOR_LOCK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /** @internal */
   outputTable = {
     message: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_commit.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_commit.ts
@@ -25,7 +25,7 @@ export class IasqlCommit extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_ALWAYS;
-  inputTable = [];
+  inputTable = {};
   /** @internal */
   outputTable = {
     action: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_commit.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_commit.ts
@@ -25,6 +25,7 @@ export class IasqlCommit extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_ALWAYS;
+  /** @internal */
   inputTable = {};
   /** @internal */
   outputTable = {

--- a/src/modules/iasql_functions/rpcs/iasql_commit.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_commit.ts
@@ -25,6 +25,7 @@ export class IasqlCommit extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_ALWAYS;
+  inputTable = [];
   /** @internal */
   outputTable = {
     action: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
@@ -32,6 +32,9 @@ export class IasqlGetErrors extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /**
+   * @internal
+   */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
@@ -32,7 +32,7 @@ export class IasqlGetErrors extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_errors.ts
@@ -32,6 +32,7 @@ export class IasqlGetErrors extends RpcBase {
    * @internal
    */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
@@ -34,7 +34,9 @@ export class IasqlGetSqlSince extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable: RpcInput = [{ argName: 'limitDate', argType: 'varchar', default: 'NULL' }];
+  inputTable: RpcInput = {
+    limitDate: { argType: 'varchar', default: null, rawDefault: true },
+  };
   /** @internal */
   outputTable = {
     sql: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
@@ -6,6 +6,7 @@ import { snakeCase } from 'typeorm/util/StringUtils';
 
 import { IasqlFunctions } from '..';
 import * as AllModules from '../../../modules';
+import { RpcInput } from '../../../modules';
 import { getCloudId } from '../../../services/cloud-id';
 import logger from '../../../services/logger';
 import { TypeormWrapper } from '../../../services/typeorm';
@@ -33,6 +34,7 @@ export class IasqlGetSqlSince extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable: RpcInput = [{ ArgName: 'limitDate', ArgType: 'varchar' }];
   /** @internal */
   outputTable = {
     sql: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
@@ -34,6 +34,7 @@ export class IasqlGetSqlSince extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable: RpcInput = {
     limitDate: { argType: 'varchar', default: null, rawDefault: true },
   };

--- a/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_get_sql_since.ts
@@ -34,7 +34,7 @@ export class IasqlGetSqlSince extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable: RpcInput = [{ ArgName: 'limitDate', ArgType: 'varchar' }];
+  inputTable: RpcInput = [{ argName: 'limitDate', argType: 'varchar', default: 'NULL' }];
   /** @internal */
   outputTable = {
     sql: 'varchar',

--- a/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
@@ -30,7 +30,7 @@ export class IasqlModulesList extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
@@ -30,6 +30,7 @@ export class IasqlModulesList extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_modules_list.ts
@@ -30,6 +30,7 @@ export class IasqlModulesList extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_preview.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview.ts
@@ -30,6 +30,7 @@ export class IasqlPreview extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview.ts
@@ -30,7 +30,7 @@ export class IasqlPreview extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview.ts
@@ -30,6 +30,7 @@ export class IasqlPreview extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
@@ -19,6 +19,7 @@ export class IasqlPreviewApply extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
@@ -19,7 +19,7 @@ export class IasqlPreviewApply extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_apply.ts
@@ -19,6 +19,7 @@ export class IasqlPreviewApply extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
@@ -19,6 +19,7 @@ export class IasqlPreviewSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
@@ -19,7 +19,7 @@ export class IasqlPreviewSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_preview_sync.ts
@@ -19,6 +19,7 @@ export class IasqlPreviewSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_rollback.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_rollback.ts
@@ -32,7 +32,7 @@ export class IasqlRollback extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_IF_SUCCEED;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_rollback.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_rollback.ts
@@ -32,6 +32,7 @@ export class IasqlRollback extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_IF_SUCCEED;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_rollback.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_rollback.ts
@@ -32,6 +32,7 @@ export class IasqlRollback extends RpcBase {
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.UNLOCK_IF_SUCCEED;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_sync.ts
@@ -19,7 +19,7 @@ export class IasqlSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
-  inputTable = [];
+  inputTable = {};
   /**
    * @internal
    */

--- a/src/modules/iasql_functions/rpcs/iasql_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_sync.ts
@@ -19,6 +19,7 @@ export class IasqlSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  /** @internal */
   inputTable = {};
   /**
    * @internal

--- a/src/modules/iasql_functions/rpcs/iasql_sync.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_sync.ts
@@ -19,6 +19,7 @@ export class IasqlSync extends RpcBase {
   preTransactionCheck = PreTransactionCheck.NO_CHECK;
   /** @internal */
   postTransactionCheck = PostTransactionCheck.NO_CHECK;
+  inputTable = [];
   /**
    * @internal
    */

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -23,7 +23,7 @@ export type Context = { [key: string]: any };
 
 // TODO: use something better than ColumnType for possible postgres colum types
 export type RpcOutput = { [key: string]: ColumnType };
-export type RpcInput = { ArgMode?: string; ArgName: string; ArgType: string; Default?: string }[];
+export type RpcInput = { argMode?: string; argName: string; argType: string; default?: string }[];
 
 export type RpcResponseObject<T> = { [Properties in keyof T]: any };
 
@@ -385,7 +385,7 @@ export class RpcBase implements RpcInterface {
   module: ModuleInterface;
   outputTable: RpcOutput;
   inputTable: RpcInput = [
-    { ArgMode: 'VARIADIC', ArgName: '_args', ArgType: 'TEXT[]', Default: 'ARRAY[]::text[]' },
+    { argMode: 'VARIADIC', argName: '_args', argType: 'TEXT[]', default: 'ARRAY[]::text[]' },
   ];
   preTransactionCheck: PreTransactionCheck;
   postTransactionCheck: PostTransactionCheck;
@@ -407,7 +407,7 @@ export class RpcBase implements RpcInterface {
   }
 
   getInstallUninstallSql(key: string) {
-    const finalInputNames = _.map(_.map(this.inputTable, 'ArgName'), snakeCase);
+    const finalInputNames = _.map(_.map(this.inputTable, 'argName'), snakeCase);
     const commonElements = _.intersection(finalInputNames, _.keys(this.outputTable));
     if (!!commonElements.length)
       throw new Error(
@@ -415,15 +415,15 @@ export class RpcBase implements RpcInterface {
       );
 
     const rpcInputArgs = this.inputTable
-      .map((value: { ArgMode?: string; ArgName: string; ArgType: string; Default?: string }) => {
-        if (value.Default)
-          return `${value.ArgMode ?? ''} ${snakeCase(value.ArgName)} ${value.ArgType} = ${value.Default}`;
-        return `${value.ArgMode ?? ''} ${snakeCase(value.ArgName)} ${value.ArgType}`;
+      .map((value: { argMode?: string; argName: string; argType: string; default?: string }) => {
+        if (value.default)
+          return `${value.argMode ?? ''} ${snakeCase(value.argName)} ${value.argType} = ${value.default}`;
+        return `${value.argMode ?? ''} ${snakeCase(value.argName)} ${value.argType}`;
       }) // https://www.postgresql.org/docs/current/sql-createfunction.html
       .join(', ');
     let rpcInputArgsForPost;
-    if (this.inputTable.length === 1 && this.inputTable[0].ArgMode?.toLowerCase() === 'variadic') {
-      rpcInputArgsForPost = this.inputTable[0].ArgName; // simply pass the array, don't wrap in another one
+    if (this.inputTable.length === 1 && this.inputTable[0].argMode?.toLowerCase() === 'variadic') {
+      rpcInputArgsForPost = this.inputTable[0].argName; // simply pass the array, don't wrap in another one
     } else {
       rpcInputArgsForPost = finalInputNames.join(', ');
       rpcInputArgsForPost = `(SELECT array[${rpcInputArgsForPost}]::varchar[])`;

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -412,7 +412,7 @@ export class RpcBase implements RpcInterface {
   getRpcInput() {
     // https://www.postgresql.org/docs/current/sql-createfunction.html
     const inputArgs = [];
-    let postArgs = '';
+    let postArgs: string;
     for (const [k, v] of Object.entries(this.inputTable)) {
       if (typeof v === 'string') {
         // argName => argType syntax

--- a/src/modules/interfaces.ts
+++ b/src/modules/interfaces.ts
@@ -23,6 +23,7 @@ export type Context = { [key: string]: any };
 
 // TODO: use something better than ColumnType for possible postgres colum types
 export type RpcOutput = { [key: string]: ColumnType };
+export type RpcInput = { ArgMode?: string; ArgName: string; ArgType: string; Default?: string }[];
 
 export type RpcResponseObject<T> = { [Properties in keyof T]: any };
 
@@ -383,6 +384,9 @@ export class MapperBase<E extends {}> {
 export class RpcBase implements RpcInterface {
   module: ModuleInterface;
   outputTable: RpcOutput;
+  inputTable: RpcInput = [
+    { ArgMode: 'VARIADIC', ArgName: '_args', ArgType: 'TEXT[]', Default: 'ARRAY[]::text[]' },
+  ];
   preTransactionCheck: PreTransactionCheck;
   postTransactionCheck: PostTransactionCheck;
   call: (
@@ -403,16 +407,33 @@ export class RpcBase implements RpcInterface {
   }
 
   getInstallUninstallSql(key: string) {
+    const finalInputNames = _.map(_.map(this.inputTable, 'ArgName'), snakeCase);
+    const commonElements = _.intersection(finalInputNames, _.keys(this.outputTable));
+    if (!!commonElements.length)
+      throw new Error(
+        `A variable name can't be both input and output in ${key} RPC: ${commonElements.join(', ')}`,
+      );
+
+    const rpcInputArgs = this.inputTable
+      .map((value: { ArgMode?: string; ArgName: string; ArgType: string; Default?: string }) => {
+        if (value.Default)
+          return `${value.ArgMode ?? ''} ${snakeCase(value.ArgName)} ${value.ArgType} = ${value.Default}`;
+        return `${value.ArgMode ?? ''} ${snakeCase(value.ArgName)} ${value.ArgType}`;
+      }) // https://www.postgresql.org/docs/current/sql-createfunction.html
+      .join(', ');
+    let rpcInputArgsForPost;
+    if (this.inputTable.length === 1 && this.inputTable[0].ArgMode?.toLowerCase() === 'variadic') {
+      rpcInputArgsForPost = this.inputTable[0].ArgName; // simply pass the array, don't wrap in another one
+    } else {
+      rpcInputArgsForPost = finalInputNames.join(', ');
+      rpcInputArgsForPost = `(SELECT array[${rpcInputArgsForPost}]::varchar[])`;
+    }
     const rpcOutputEntries = Object.entries(this.outputTable ?? {});
     const rpcOutputTable = rpcOutputEntries
       .map(([columnName, columnType]) => `${columnName} ${columnType}`)
       .join(', ');
     const afterInstallSql = `
-        create or replace function ${snakeCase(
-          key,
-        )}(variadic _args text[] default array[]::text[]) returns table (
-          ${rpcOutputTable}
-        )
+        create or replace function ${snakeCase(key)}(${rpcInputArgs}) returns table (${rpcOutputTable})
         language plpgsql security definer
         as $$
         declare
@@ -425,7 +446,7 @@ export class RpcBase implements RpcInterface {
             json_build_object(
               'dbId', current_database(),
               'dbUser', SESSION_USER,
-              'params', _args,
+              'params', ${rpcInputArgsForPost},
               'modulename', '${this.module.name}',
               'methodname', '${key}',
               'preTransaction', '${this.preTransactionCheck}',
@@ -483,7 +504,7 @@ export class AwsSdkInvoker extends RpcBase {
       `
         create or replace function ${snakeCase(
           key,
-        )}(method_name ${inputEnumName}, method_input json, region varchar) returns table (
+        )}(method_name ${inputEnumName}, method_input json, region varchar default default_aws_region()) returns table (
           ${rpcOutputTable}
         )
         language plpgsql security definer
@@ -498,7 +519,7 @@ export class AwsSdkInvoker extends RpcBase {
             json_build_object(
               'dbId', current_database(),
               'dbUser', SESSION_USER,
-              'params', (SELECT array[method_name::varchar, method_input::varchar, region]),
+              'params', (SELECT array[method_name, method_input, region]::varchar[]),
               'modulename', '${this.module.name}',
               'methodname', '${key}',
               'preTransaction', '${this.preTransactionCheck}',
@@ -526,21 +547,8 @@ export class AwsSdkInvoker extends RpcBase {
           ) as j;
         end;
         $$;
-        -- function overloading with the last input replaced by default_aws_region()
-        create or replace function ${snakeCase(
-          key,
-        )}(method_name ${inputEnumName}, method_input json) returns table (
-          ${rpcOutputTable}
-        )
-        language plpgsql security definer
-        as $$
-        begin
-          RETURN QUERY SELECT ${snakeCase(key)}(method_name, method_input, default_aws_region());
-        end;
-        $$;
       `;
     const beforeUninstallSql = `
-        DROP FUNCTION "${snakeCase(key)}"(${inputEnumName}, json);
         DROP FUNCTION "${snakeCase(key)}"(${inputEnumName}, json, varchar);
         DROP TYPE ${inputEnumName};
       `;

--- a/test/modules/aws-acm-import-integration.ts
+++ b/test/modules/aws-acm-import-integration.ts
@@ -84,7 +84,7 @@ describe('AwsAcm Import Integration Testing', () => {
   itDocs(
     'adds a new certificate to import',
     query(`
-    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
+    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '{}');
   `),
   );
 
@@ -148,7 +148,7 @@ describe('AwsAcm Import Integration Testing', () => {
   itDocs(
     'import a certificate in non-default region',
     query(`
-    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
+    SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '{}');
   `),
   );
 

--- a/test/modules/aws-acm-request-integration.ts
+++ b/test/modules/aws-acm-request-integration.ts
@@ -81,7 +81,7 @@ describe('AwsAcm Request Integration Testing', () => {
 
   it('adds a new certificate to request with a domain without route53 support', done => {
     query(`
-        SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '');
+        SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '{}');
       `)((e: any) => {
       if (e instanceof Error) {
         return done();
@@ -95,7 +95,7 @@ describe('AwsAcm Request Integration Testing', () => {
   it(
     'adds a new certificate to request with a fake domain',
     query(`
-      SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '');
+      SELECT * FROM certificate_request('fakeDomain.com', 'DNS', '${region}', '{}');
     `),
   );
 
@@ -114,7 +114,7 @@ describe('AwsAcm Request Integration Testing', () => {
   itDocs(
     'adds a new certificate to request',
     query(`
-      SELECT * FROM certificate_request('${domainName}', 'DNS', '${region}', '');
+      SELECT * FROM certificate_request('${domainName}', 'DNS', '${region}', '{}');
   `),
   );
 
@@ -178,7 +178,7 @@ describe('AwsAcm Request Integration Testing', () => {
   itDocs(
     'creates a certificate request in non-default region',
     query(`
-      SELECT * FROM certificate_request('${domainName}', 'DNS', 'us-east-1', '');
+      SELECT * FROM certificate_request('${domainName}', 'DNS', 'us-east-1', '{}');
   `),
   );
 

--- a/test/modules/aws-cloudfront-integration.ts
+++ b/test/modules/aws-cloudfront-integration.ts
@@ -311,7 +311,7 @@ describe('Cloudfront Integration Testing', () => {
   it(
     'imports a certificate to use in cloudfront distribution',
     query(`
-    SELECT * FROM certificate_import('${cert}', '${key}', 'us-east-1', '');
+    SELECT * FROM certificate_import('${cert}', '${key}', 'us-east-1', '{}');
   `),
   );
 

--- a/test/modules/aws-elb-integration.ts
+++ b/test/modules/aws-elb-integration.ts
@@ -445,7 +445,7 @@ describe('ELB Integration Testing', () => {
   itDocs(
     'adds a new certificate to import',
     query(`
-      SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '');
+      SELECT * FROM certificate_import('${cert}', '${key}', '${region}', '{}');
   `),
   );
 

--- a/test/modules/aws-lambda-integration.ts
+++ b/test/modules/aws-lambda-integration.ts
@@ -274,7 +274,7 @@ describe('Lambda Integration Testing', () => {
     FROM invoke_lambda_function();
   `)((e?: any) => {
       try {
-        expect(e?.message).toContain('Please provide a valid lambda function name');
+        expect(e?.message).toContain('function invoke_lambda_function() does not exist');
       } catch (err) {
         done(err);
         return {};
@@ -286,7 +286,7 @@ describe('Lambda Integration Testing', () => {
   it('should fail invoking with wrong payload', done =>
     void query(`
       SELECT *
-      FROM invoke_lambda_function('${lambdaFunctionName}', '{name: test}');
+      FROM invoke_lambda_function('${lambdaFunctionName}', '{"name": "test"}');
   `)((e?: any) => {
       try {
         expect(e?.message).toContain('The payload must be a valid JSON string');

--- a/test/modules/aws-lambda-integration.ts
+++ b/test/modules/aws-lambda-integration.ts
@@ -286,10 +286,10 @@ describe('Lambda Integration Testing', () => {
   it('should fail invoking with wrong payload', done =>
     void query(`
       SELECT *
-      FROM invoke_lambda_function('${lambdaFunctionName}', '{"name": "test"}');
+      FROM invoke_lambda_function('${lambdaFunctionName}', '{name: test}');
   `)((e?: any) => {
       try {
-        expect(e?.message).toContain('The payload must be a valid JSON string');
+        expect(e?.message).toContain('invalid input syntax for type json');
       } catch (err) {
         done(err);
         return {};


### PR DESCRIPTION
Probably I've not taken the best approach, so I'd really appreciate your feedbacks. This is what I've done:
- Add `inputTable` field to the RpcBase class. It's from `RpcInput` type which is a list of different things needed for [creation of Postgres function input](https://www.postgresql.org/docs/current/sql-createfunction.html):
```typescript
export type RpcInput = { ArgMode?: string; ArgName: string; ArgType: string; Default?: string }[];
```
```
( [ [ argmode ] [ argname ] argtype [ { DEFAULT | = } default_expr ] [, ...] ] )
```

- Create the input strings based on the above syntax and put it into `rpcInputArgs` variable. 
- If there's just a single `VARIADIC` input, just pass it along to `http_post` (and not wrap into another `ARRAY`), but if the arguments are different, make a new `SELECT array[${rpcInputArgsForPost}]::varchar[]` out of them.
- Name of the inputs and the outputs can't be the same, so I've added checks in our code so that we don't have to wait for Postgres to trigger the error.