### PR TITLE
Don't let `console.log` format objects and don't use TypeORM `ConnectionManager`

### DIFF
--- a/src/router/db.ts
+++ b/src/router/db.ts
@@ -225,6 +225,8 @@ db.post('/rpc', async (req: Request, res: Response) => {
           );
       } catch (e: any) {
         logger.error('could not log op event', e);
+      } finally {
+        await conn.dropConn();
       }
     }
   } catch (e: any) {

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -19,7 +19,7 @@ const logFactory: LogFunctionFactory<Logger> = (scope: any) => {
     });
     logfn.on('error', event => {
       if (event.retrying) return;
-      console.log('Fatal error in LogDNA', event);
+      console.log(`Fatal error in LogDNA ${util.inspect(event)}`);
     });
     if (config.logger.forceLocal) {
       return async (level, message, meta) => {
@@ -29,7 +29,7 @@ const logFactory: LogFunctionFactory<Logger> = (scope: any) => {
           const user = await MetadataRepo.getUserFromDbId(dbId);
           userId = user?.id;
         }
-        console.log(`${level}: ${message}`, { ...meta, userId, dbId });
+        console.log(`${level}: ${message} ${util.inspect({ ...meta, userId, dbId })}`);
         logfn.log(message, {
           level: level === 'warning' ? 'warn' : level, // Graphile Logger vs LogDNA levels fix
           meta: { ...meta, userId, dbId },
@@ -74,11 +74,11 @@ const logFactory: LogFunctionFactory<Logger> = (scope: any) => {
     return (level, message, meta) => {
       switch (level) {
         case 'error':
-          console.error(level, message, scope, meta);
+          console.error(`${level}: ${message} ${util.inspect(scope)}  ${util.inspect(meta)}`);
           break;
         case 'debug':
         default:
-          console.log(level, message, scope, meta);
+          console.log(`${level}: ${message} ${util.inspect(scope)}  ${util.inspect(meta)}`);
           break;
       }
     };
@@ -102,12 +102,12 @@ const logFactory: LogFunctionFactory<Logger> = (scope: any) => {
     return (level, message, meta) => {
       switch (level) {
         case 'error':
-          console.error(level, message, scope, meta);
+          console.error(`${level}: ${message} ${util.inspect(scope)}  ${util.inspect(meta)}`);
           break;
         case 'debug':
           break;
         default:
-          console.log(level, message, scope, meta);
+          console.log(`${level}: ${message} ${util.inspect(scope)}  ${util.inspect(meta)}`);
           break;
       }
     };

--- a/test/common/basic-db.ts
+++ b/test/common/basic-db.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import { createConnection, EntityTarget } from 'typeorm';
+import { Connection, EntityTarget } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 import * as Entities from '../../src/modules/iasql_platform/entity';
@@ -14,7 +14,7 @@ beforeAll(done => {
     // Spin up the Postgres server and wait for it to start
     execSync('cd test && docker-compose up -d && sleep 5');
     // Create the test database
-    const conn = await createConnection({
+    const conn = await new Connection({
       name: 'startup',
       type: 'postgres',
       username: 'postgres',
@@ -22,7 +22,7 @@ beforeAll(done => {
       host: 'localhost',
       port: 5432,
       database: 'postgres',
-    });
+    }).connect();
     await conn.query('CREATE DATABASE test');
     await conn.close();
     done();
@@ -32,14 +32,14 @@ beforeAll(done => {
 afterAll(done => {
   (async () => {
     // Destroy the test database
-    const conn = await createConnection({
+    const conn = await new Connection({
       name: 'shutdown',
       type: 'postgres',
       username: 'postgres',
       password: 'test',
       host: 'localhost',
       database: 'postgres',
-    });
+    }).connect();
     await conn.query('DROP DATABASE test');
     await conn.close();
     // Finally turn off the postgres server
@@ -51,14 +51,14 @@ afterAll(done => {
 describe('Basic DB testing', () => {
   it('should run the migrations correctly', done => {
     (async () => {
-      const conn = await createConnection({
+      const conn = await new Connection({
         name: 'test',
         type: 'postgres',
         username: 'postgres',
         password: 'test',
         host: 'localhost',
         database: 'test',
-      });
+      }).connect();
 
       // Migrate in the database
       await migrate(conn);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import express from 'express';
 import fs from 'fs';
-import { createConnection } from 'typeorm';
+import { Connection } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 
 import config from '../src/config';
@@ -111,7 +111,7 @@ export function runQuery(
   return function (done: (e?: any) => {}) {
     const { username, password } = withUserAndPassword();
     if (log) logger.info(queryString);
-    createConnection({
+    new Connection({
       name: uuidv4(),
       type: 'postgres',
       username,
@@ -120,7 +120,7 @@ export function runQuery(
       port: 5432,
       database: databaseName,
       extra: { ssl: false },
-    }).then(conn => {
+    }).connect().then(conn => {
       conn.query(queryString).then(
         (res: any[]) => {
           conn.close().then(

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -120,32 +120,34 @@ export function runQuery(
       port: 5432,
       database: databaseName,
       extra: { ssl: false },
-    }).connect().then(conn => {
-      conn.query(queryString).then(
-        (res: any[]) => {
-          conn.close().then(
-            ...finish((_e?: any) => {
-              if (assertFn) {
-                try {
-                  assertFn(res);
-                } catch (e: any) {
-                  done(e);
-                  return {};
+    })
+      .connect()
+      .then(conn => {
+        conn.query(queryString).then(
+          (res: any[]) => {
+            conn.close().then(
+              ...finish((_e?: any) => {
+                if (assertFn) {
+                  try {
+                    assertFn(res);
+                  } catch (e: any) {
+                    done(e);
+                    return {};
+                  }
                 }
-              }
-              done();
-              return {};
-            }),
-          );
-        },
-        e => {
-          conn.close().then(
-            () => done(e),
-            e2 => done(e2),
-          );
-        },
-      );
-    }, done);
+                done();
+                return {};
+              }),
+            );
+          },
+          e => {
+            conn.close().then(
+              () => done(e),
+              e2 => done(e2),
+            );
+          },
+        );
+      }, done);
   };
 }
 


### PR DESCRIPTION
Digging through memory dumps and this appears to be ~50% of our "memory leak" because `console.log` holds on to the objects passed to it *forever* for whatever dumb reason.