### PR TITLE
Remove reference to 'iasql_upgrade' function from 'iasql_help'

### DIFF
--- a/src/modules/iasql_functions/sql/after_install.sql
+++ b/src/modules/iasql_functions/sql/after_install.sql
@@ -87,7 +87,6 @@ begin
     {"name": "uninstall", "signature": "iasql_uninstall(variadic text[])", "description": "Uninstall modules in the hosted db", "sample_usage": "SELECT * FROM iasql_uninstall(''aws_vpc'', ''aws_ec2'')"},
     {"name": "modules_list", "signature": "iasql_modules_list()", "description": "Lists all modules available to be installed", "sample_usage": "SELECT * FROM iasql_modules_list()"},
     {"name": "modules_installed", "signature": "iasql_modules_installed()", "description": "Lists all modules currently installed in the hosted db", "sample_usage": "SELECT * FROM iasql_modules_installed()"},
-    {"name": "upgrade", "signature": "iasql_upgrade()", "description": "Upgrades the db to the latest IaSQL Platform", "sample_usage": "SELECT iasql_upgrade()"},
     {"name": "version", "signature": "iasql_version()", "description": "Lists the currently installed IaSQL Platform version", "sample_usage": "SELECT * from iasql_version()"}
   ]') as x(name text, signature text, description text, sample_usage text);
 end;


### PR DESCRIPTION
I noticed while working on other things last night that `iasql_help` still referred to an `iasql_upgrade` function that hasn't existed for a few releases now.

We should also see about potentially automating the output here so it can also include the RPCs from other modules if/when installed.