### PR TITLE
Disable the worker pool in the local environment

### DIFF
--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -4,7 +4,7 @@ const config: ConfigInterface = {
   http: {
     host: 'localhost',
     port: 8088,
-    workerPool: true,
+    workerPool: false,
   },
   db: {
     host: 'localhost',


### PR DESCRIPTION
This was meant to handle multi-user environments and is just a waste of RAM in the local env. (And that apparently matters with Docker on not-Linux)