### PR TITLE
Drop arm/v7 support because while Docker supports it, it seems Postgres doesn't

### DIFF
--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: iasql/iasql:latest, iasql/iasql:${{ github.event.client_payload.version }}${{ github.event.client_payload.message.version }}${{ github.event.inputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Informational only. Only way to test is on `main` :/
