### PR TITLE
Keep the three package.json version numbers in sync

### DIFF
--- a/.develop.sh
+++ b/.develop.sh
@@ -27,7 +27,6 @@ yarn format
 # Same for the dashboard
 cd dashboard
 yarn
-yarn format
 cd ..
 
 # Same for the site

--- a/.develop.sh
+++ b/.develop.sh
@@ -15,6 +15,8 @@ CONFIGVERSION="$(cat src/config/index.ts | sed "s/^  version:.*/version: '${VERS
 
 # Update the package metadata with the specified version
 PACKAGEJSON="$(jq ".version = \"${VERSION}-beta\"" package.json)" && echo "${PACKAGEJSON}" > package.json
+PACKAGEJSON="$(jq ".version = \"${VERSION}-beta\"" dashboard/package.json)" && echo "${PACKAGEJSON}" > dashboard/package.json
+PACKAGEJSON="$(jq ".version = \"${VERSION}-beta\"" site/package.json)" && echo "${PACKAGEJSON}" > site/package.json
 
 # Make sure the lockfiles are updated, too
 yarn
@@ -22,7 +24,18 @@ yarn
 # Make sure it's all formatted the way we want it
 yarn format
 
+# Same for the dashboard
+cd dashboard
+yarn
+yarn format
+cd ..
+
+# Same for the site
+cd site
+yarn
+cd ..
+
 # Commit the version and push to main
-git add package.json yarn.lock src/config/index.ts
+git add package.json yarn.lock src/config/index.ts dashboard/package.json dashboard/yarn.lock site/package.json site/yarn.lock
 git commit -m "Prepare version ${VERSION}-beta for development"
 git push origin main

--- a/.version.sh
+++ b/.version.sh
@@ -17,6 +17,8 @@ CONFIGVERSION="$(cat src/config/index.ts | sed "s/^  version:.*/version: '${VERS
 
 # Update the package metadata with the specified version
 PACKAGEJSON="$(jq ".version = \"${VERSION}\"" package.json)" && echo "${PACKAGEJSON}" > package.json
+PACKAGEJSON="$(jq ".version = \"${VERSION}\"" dashboard/package.json)" && echo "${PACKAGEJSON}" > dashboard/package.json
+PACKAGEJSON="$(jq ".version = \"${VERSION}\"" site/package.json)" && echo "${PACKAGEJSON}" > site/package.json
 
 # Make sure the lockfiles are updated, too
 yarn
@@ -24,8 +26,19 @@ yarn
 # Make sure it's all formatted the way we want it
 yarn format
 
+# Same for the dashboard
+cd dashboard
+yarn
+yarn format
+cd ..
+
+# Same for the site
+cd site
+yarn
+cd ..
+
 # Commit and tag the update
-git add package.json yarn.lock src/config/index.ts
+git add package.json yarn.lock src/config/index.ts dashboard/package.json dashboard/yarn.lock site/package.json site/yarn.lock
 git commit -m "v${VERSION}"
 git push origin main
 gh release create v${VERSION} -t v${VERSION} -n v${VERSION} --target main

--- a/.version.sh
+++ b/.version.sh
@@ -29,7 +29,6 @@ yarn format
 # Same for the dashboard
 cd dashboard
 yarn
-yarn format
 cd ..
 
 # Same for the site


### PR DESCRIPTION
This was noticed in the last release. A minor glitch which should be fixed by these two script changes