### PR TITLE
fix: do not return empty response when we have affected_records

### DIFF
--- a/dashboard/src/components/QueryResult.tsx
+++ b/dashboard/src/components/QueryResult.tsx
@@ -37,10 +37,10 @@ export default function QueryResult() {
         )}
 
       {!!queryRes &&
-        queryRes instanceof Array && !("affected_records" in queryRes[0]) &&
+        queryRes instanceof Array &&
+        !('affected_records' in queryRes[0]) &&
         (queryRes[0]?.result ?? []) instanceof Array &&
         queryRes.filter((r: any) => (r.result ?? []).length > 0).length === 0 && (
-          
           <Label>Empty response</Label>
         )}
     </VBox>

--- a/dashboard/src/components/QueryResult.tsx
+++ b/dashboard/src/components/QueryResult.tsx
@@ -35,10 +35,12 @@ export default function QueryResult() {
             />
           </VBox>
         )}
+
       {!!queryRes &&
-        queryRes instanceof Array &&
+        queryRes instanceof Array && !("affected_records" in queryRes[0]) &&
         (queryRes[0]?.result ?? []) instanceof Array &&
         queryRes.filter((r: any) => (r.result ?? []).length > 0).length === 0 && (
+          
           <Label>Empty response</Label>
         )}
     </VBox>


### PR DESCRIPTION
crud operations actually do not return result, but instead return affected_records, so check that before returning empty response