### PR TITLE
Rollback should unlock always, even on failure as `iasql_commit`

### DIFF
--- a/src/modules/iasql_functions/rpcs/iasql_rollback.ts
+++ b/src/modules/iasql_functions/rpcs/iasql_rollback.ts
@@ -31,7 +31,7 @@ export class IasqlRollback extends RpcBase {
   /** @internal */
   preTransactionCheck = PreTransactionCheck.FAIL_IF_NOT_LOCKED;
   /** @internal */
-  postTransactionCheck = PostTransactionCheck.UNLOCK_IF_SUCCEED;
+  postTransactionCheck = PostTransactionCheck.UNLOCK_ALWAYS;
   /** @internal */
   inputTable = {};
   /**


### PR DESCRIPTION
Resolves #2163 