### PR TITLE
Upgrade the module migration postgres to Postgres 14

### DIFF
--- a/.module_migration.sh
+++ b/.module_migration.sh
@@ -15,7 +15,7 @@ docker volume prune -f
 docker image prune -f
 
 # Start a postgres container
-docker container run -p 5432:5432 -e POSTGRES_PASSWORD=test --name migrate-postgres -d postgres:13.4
+docker container run -p 5432:5432 -e POSTGRES_PASSWORD=test --name migrate-postgres -d postgres:14.7
 
 sleep 5 # Just in case
 psql postgresql://postgres:test@localhost:5432/postgres -c "CREATE DATABASE __example__"


### PR DESCRIPTION
We're using Postgres 14 within our docker container but building migrations with Postgres 13. Normally shouldn't matter, but in case there's a Postgres 14-only feature we want to use, would be better to keep them in sync