### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set registry image tag
         run: |
           DEPLOY_TAG=${{inputs.deploy_tag}}
-          echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql:$DEPLOY_TAG"
+          echo "registry-image-tag=ghcr.io/iasql/iasql:$DEPLOY_TAG" >> $GITHUB_OUTPUT
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         id: format-version
         run: |
           VERSION="$(jq -r '.version' package.json)"
-          echo ::set-output name=version::${VERSION}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Emit for doc generation
         uses: mvasigh/dispatch-action@main

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set registry image tag
         run: |
           COMMIT_SHA=${{inputs.commit_sha}}
-          echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql:$(echo ${COMMIT_SHA:-$GITHUB_SHA})"
+          echo "registry-image-tag=ghcr.io/iasql/iasql:$(echo ${COMMIT_SHA:-$GITHUB_SHA})" >> $GITHUB_OUTPUT
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-all-accounts.yml
+++ b/.github/workflows/tests-all-accounts.yml
@@ -17,10 +17,10 @@ jobs:
       - id: set-test-modules
         name: Set all numbers
         run: >
-          echo "::set-output name=test-accounts::$(node -e 'console.log(JSON.stringify([...Array(100).keys()]))')"
+          echo "test-accounts=$(node -e 'console.log(JSON.stringify([...Array(100).keys()]))')" >> $GITHUB_OUTPUT
       - id: set-registry-image-tag
         name: Set registry image tag
-        run: echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql:$GITHUB_SHA"
+        run: echo "registry-image-tag=ghcr.io/iasql/iasql:$GITHUB_SHA" >> $GITHUB_OUTPUT
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-django.yml
+++ b/.github/workflows/tests-django.yml
@@ -43,7 +43,7 @@ jobs:
           regions=("ap-northeast-1" "ap-northeast-2" "ap-northeast-3" "ap-south-1" "ap-southeast-1" "ap-southeast-2" "ca-central-1" "eu-central-1" "eu-north-1" "eu-west-1" "eu-west-2" "eu-west-3" "sa-east-1" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
           regionslen=${#regions[@]}
           index=$(($RANDOM % $regionslen))
-          echo "::set-output name=region::$(echo ${regions[$index]})"
+          echo "region=$(echo ${regions[$index]})" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
           RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' ${LAMBDA_FUNCTION} 2>/dev/null)
           echo $RESPONSE
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
-          echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
+          echo "account_index=$(echo ${ACCOUNT_INDEX})" >> $GITHUB_OUTPUT
 
       - name: Setup IaSQL database
         id: set-up-database

--- a/.github/workflows/tests-prisma.yml
+++ b/.github/workflows/tests-prisma.yml
@@ -43,7 +43,7 @@ jobs:
           regions=("ap-northeast-1" "ap-northeast-2" "ap-northeast-3" "ap-south-1" "ap-southeast-1" "ap-southeast-2" "ca-central-1" "eu-central-1" "eu-north-1" "eu-west-1" "eu-west-2" "eu-west-3" "sa-east-1" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
           regionslen=${#regions[@]}
           index=$(($RANDOM % $regionslen))
-          echo "::set-output name=region::$(echo ${regions[$index]})"
+          echo "region=$(echo ${regions[$index]})" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
           RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' ${LAMBDA_FUNCTION} 2>/dev/null)
           echo $RESPONSE
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
-          echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
+          echo "account_index=$(echo ${ACCOUNT_INDEX})" >> $GITHUB_OUTPUT
 
       - name: Setup IaSQL database
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,10 +89,10 @@ jobs:
       - id: set-common-tests
         name: Set common tests
         run: >
-          echo "::set-output name=common-tests::$(npx jest **/common/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
+          echo "common-tests=$(npx jest **/common/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')" >> $GITHUB_OUTPUT
       - id: set-common-test-names
         name: Set common test names
-        run: echo "::set-output name=common-test-names::$(npx jest **/common/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        run: echo "common-test-names=$(npx jest **/common/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')" >> $GITHUB_OUTPUT
 
   common-test:
     runs-on: ubuntu-latest
@@ -140,10 +140,10 @@ jobs:
       - id: set-basic-integration-tests
         name: Set basic integration tests
         run: >
-          echo "::set-output name=basic-integration-tests::$(npx jest **/basic_integration/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
+          echo "basic-integration-tests=$(npx jest **/basic_integration/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')" >> $GITHUB_OUTPUT
       - id: set-basic-integration-test-names
         name: Set basic integration test names
-        run: echo "::set-output name=basic-integration-test-names::$(npx jest **/basic_integration/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        run: echo "basic-integration-test-names=$(npx jest **/basic_integration/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')" >> $GITHUB_OUTPUT
 
   basic-integration-test:
     runs-on: ubuntu-latest
@@ -175,7 +175,7 @@ jobs:
           RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' ${LAMBDA_FUNCTION} 2>/dev/null)
           echo $RESPONSE
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
-          echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
+          echo "account_index=$(echo ${ACCOUNT_INDEX})" >> $GITHUB_OUTPUT
 
       - name: Run basic-integration tests
         uses: nick-fields/retry@v2
@@ -272,13 +272,13 @@ jobs:
       - id: set-test-modules
         name: Set modules tests
         run: >
-          echo "::set-output name=test-modules::$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')"
+          echo "test-modules=$(npx jest **/modules/* --listTests --json | jq -c 'map({(. | split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring): .}) | add')" >> $GITHUB_OUTPUT
       - id: set-test-module-names
         name: Set modules tests names
-        run: echo "::set-output name=test-module-names::$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')"
+        run: echo "test-module-names=$(npx jest **/modules/* --listTests --json | jq -c 'map(split("/") | .[-1] | split(".") | .[0] | gsub( "-"; "_") | ascii_upcase | tostring)')" >> $GITHUB_OUTPUT
       - id: set-registry-image-tag
         name: Set registry image tag
-        run: echo "::set-output name=registry-image-tag::ghcr.io/iasql/iasql:$GITHUB_SHA"
+        run: echo "registry-image-tag=ghcr.io/iasql/iasql:$GITHUB_SHA" >> $GITHUB_OUTPUT
 
   build-and-push:
     runs-on: ubuntu-latest
@@ -335,7 +335,7 @@ jobs:
           RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' ${LAMBDA_FUNCTION} 2>/dev/null)
           echo $RESPONSE
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
-          echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
+          echo "account_index=$(echo ${ACCOUNT_INDEX})" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -485,7 +485,7 @@ jobs:
           RESPONSE=$(curl -X POST -H "Content-Type: text/plain" -H "${SECRET_HEADER}" -d '1' ${LAMBDA_FUNCTION} 2>/dev/null)
           echo $RESPONSE
           ACCOUNT_INDEX=$(echo $RESPONSE | jq '.[0]' || exit 1)
-          echo "::set-output name=account_index::$(echo ${ACCOUNT_INDEX})"
+          echo "account_index=$(echo ${ACCOUNT_INDEX})" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
## Description

Resolve  #2187 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo ::set-output name=version::${VERSION}
```

**TO-BE**

```yml
echo "version=${VERSION}" >> $GITHUB_OUTPUT
```