### PR TITLE
Turn on Mezmo logging in local env

### DIFF
--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -17,7 +17,8 @@ const config: ConfigInterface = {
   logger: {
     debug: false,
     test: false,
-    forceLocal: false,
+    forceLocal: true,
+    logDnaKey: 'b98181227b606d8ee6c5674b5bb948e7',
   },
 };
 if (process.env.IASQL_TELEMETRY === 'on') {


### PR DESCRIPTION
With the `debug` level disabled secrets should not be shared, but we will get errors reported to us.

Resolves #2185 