### PR TITLE
remove characters that need encoding from client_reference_id

### DIFF
--- a/dashboard/src/pages/api/run.ts
+++ b/dashboard/src/pages/api/run.ts
@@ -20,7 +20,11 @@ export async function isCustomer(uid: string): Promise<boolean> {
   if (stripe === undefined) return true;
   let isCustomer = false;
   for await (const session of stripe.checkout.sessions.list()) {
-    if (!!session.customer && session.status === 'complete' && session.client_reference_id === conformUidToStripe(uid)) {
+    if (
+      !!session.customer &&
+      session.status === 'complete' &&
+      session.client_reference_id === conformUidToStripe(uid)
+    ) {
       isCustomer = true;
       break;
     }
@@ -57,7 +61,7 @@ function conformUidToStripe(uid: string) {
   // https://stripe.com/docs/payment-links/url-parameters#streamline-reconciliation-with-a-url-parameter
   // client_reference_id can be composed of alphanumeric characters, dashes, or underscores, and be any value up to 200 characters.
   // Invalid values are silently dropped so the payment page continues to work as expected, but in our case it needs to work.
-  return uid.replace(/[^a-zA-Z 0-9 _ -]+/g,'');
+  return uid.replace(/[^a-zA-Z 0-9 _ -]+/g, '');
 }
 
 function extractTokenFromHeader(e: NextApiRequest) {

--- a/dashboard/src/pages/api/run.ts
+++ b/dashboard/src/pages/api/run.ts
@@ -61,7 +61,7 @@ function conformUidToStripe(uid: string) {
   // https://stripe.com/docs/payment-links/url-parameters#streamline-reconciliation-with-a-url-parameter
   // client_reference_id can be composed of alphanumeric characters, dashes, or underscores, and be any value up to 200 characters.
   // Invalid values are silently dropped so the payment page continues to work as expected, but in our case it needs to work.
-  return uid.replace(/[^a-zA-Z 0-9 _ -]+/g, '');
+  return uid.replace(/[^a-zA-Z0-9_-]+/g, '');
 }
 
 function extractTokenFromHeader(e: NextApiRequest) {

--- a/dashboard/src/server-config/staging.ts
+++ b/dashboard/src/server-config/staging.ts
@@ -18,7 +18,7 @@ const staging: ConfigInterface = {
   },
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY ?? throwError('No Stripe Secret Key defined'),
-    paymentLink: 'https://buy.stripe.com/test_bIY3fy7X4bzz4Io000',
+    paymentLink: 'https://buy.stripe.com/test_6oE8zSelsgTT0s8001',
   },
 };
 


### PR DESCRIPTION
This was not an issue locally because uuids generated locally conformed to the stripe requirements, but the ones generated by auth0 in staging did not